### PR TITLE
Add garment try-on demo

### DIFF
--- a/TRYON_TUTORIAL.md
+++ b/TRYON_TUTORIAL.md
@@ -1,0 +1,35 @@
+# Building a Virtual Garment Try-On System
+
+This document describes the basic steps to adapt **AnyDoor** for a clothing try-on application where users upload a person image and a garment image to preview the try-on result.
+
+## 1. Prepare Data
+- Collect product images of each garment and annotate segmentation masks.
+- Optionally gather person images with ground truth segmentation.
+- Update `configs/datasets.yaml` to point to your dataset paths. You can reuse the entries `VitonHD`, `Dresscode` or `FashionTryon` as examples.
+
+## 2. Download Model Weights
+- Download the pre-trained AnyDoor checkpoint and DINOv2 weight as described in `readme.md`.
+- Edit `configs/anydoor.yaml` line 83 to set the path to the DINOv2 weight.
+- Place the AnyDoor checkpoint path in `configs/tryon_demo.yaml`.
+
+## 3. (Optional) Fine-tune on Your Dataset
+- Adjust `run_train_anydoor.py` to include only your try-on datasets.
+- Set training hyper-parameters (batch size, learning rate, etc.).
+- Run `python run_train_anydoor.py` to start fine-tuning.
+
+## 4. Run the Try-On Demo
+- Check `configs/tryon_demo.yaml` and set the paths as above.
+- Start the Gradio interface:
+
+```bash
+python run_tryon_demo.py
+```
+
+- Upload a person photo on the left and a garment image on the right. Draw rough masks on both images. Click **Generate** to preview the result.
+
+## 5. Integration Tips
+- Deploy the demo on a local server connected to a kiosk or a mobile front-end.
+- You can pre-load your store's garment images in `examples/Gradio/FG` so they appear as selectable examples in the interface.
+- For better quality, enable `Reference Mask Refine` to automatically refine the garment mask.
+
+This setup provides a starting point to build an efficient and user-friendly virtual try-on system using AnyDoor.

--- a/configs/tryon_demo.yaml
+++ b/configs/tryon_demo.yaml
@@ -1,0 +1,4 @@
+pretrained_model: path/epoch=1-step=8687.ckpt
+config_file: configs/anydoor.yaml
+save_memory: False
+use_interactive_seg: True

--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,18 @@ The gradio demo would look like the UI shown below:
   </tr>
 </table>
 
+## Clothing Try-On Demo
+We provide a simplified interface for virtual garment try-on. After setting the
+pretrained model paths in `configs/tryon_demo.yaml`, launch:
+
+```bash
+python run_tryon_demo.py
+```
+
+Users can upload a person photo and a garment image, draw rough masks on both
+images and preview the try-on result. See `TRYON_TUTORIAL.md` for detailed
+setup steps.
+
 ## Train
 
 ### Prepare datasets

--- a/run_tryon_demo.py
+++ b/run_tryon_demo.py
@@ -1,0 +1,314 @@
+import cv2
+import einops
+import numpy as np
+import torch
+import random
+import gradio as gr
+import os
+import albumentations as A
+from PIL import Image
+import torchvision.transforms as T
+from datasets.data_utils import * 
+from cldm.model import create_model, load_state_dict
+from cldm.ddim_hacked import DDIMSampler
+from omegaconf import OmegaConf
+from cldm.hack import disable_verbosity, enable_sliced_attention
+
+
+cv2.setNumThreads(0)
+cv2.ocl.setUseOpenCL(False)
+
+save_memory = False
+disable_verbosity()
+if save_memory:
+    enable_sliced_attention()
+
+
+config = OmegaConf.load('./configs/tryon_demo.yaml')
+model_ckpt =  config.pretrained_model
+model_config = config.config_file
+use_interactive_seg = config.use_interactive_seg
+
+model = create_model(model_config ).cpu()
+model.load_state_dict(load_state_dict(model_ckpt, location='cuda'))
+model = model.cuda()
+ddim_sampler = DDIMSampler(model)
+
+if use_interactive_seg:
+    from iseg.coarse_mask_refine_util import BaselineModel
+    model_path = './iseg/coarse_mask_refine.pth'
+    iseg_model = BaselineModel().eval()
+    weights = torch.load(model_path , map_location='cpu')['state_dict']
+    iseg_model.load_state_dict(weights, strict= True)
+
+
+def process_image_mask(image_np, mask_np):
+    img = torch.from_numpy(image_np.transpose((2, 0, 1)))
+    img = img.float().div(255).unsqueeze(0)
+    mask = torch.from_numpy(mask_np).float().unsqueeze(0).unsqueeze(0)
+    pred = iseg_model(img, mask)['instances'][0,0].detach().numpy() > 0.5 
+    return pred.astype(np.uint8)
+
+def crop_back( pred, tar_image,  extra_sizes, tar_box_yyxx_crop):
+    H1, W1, H2, W2 = extra_sizes
+    y1,y2,x1,x2 = tar_box_yyxx_crop    
+    pred = cv2.resize(pred, (W2, H2))
+    m = 3 # maigin_pixel
+
+    if W1 == H1:
+        tar_image[y1+m :y2-m, x1+m:x2-m, :] =  pred[m:-m, m:-m]
+        return tar_image
+
+    if W1 < W2:
+        pad1 = int((W2 - W1) / 2)
+        pad2 = W2 - W1 - pad1
+        pred = pred[:,pad1: -pad2, :]
+    else:
+        pad1 = int((H2 - H1) / 2)
+        pad2 = H2 - H1 - pad1
+        pred = pred[pad1: -pad2, :, :]
+    tar_image[y1+m :y2-m, x1+m:x2-m, :] =  pred[m:-m, m:-m]
+    return tar_image
+
+def inference_single_image(ref_image, 
+                           ref_mask, 
+                           tar_image, 
+                           tar_mask, 
+                           strength, 
+                           ddim_steps, 
+                           scale, 
+                           seed,
+                           enable_shape_control,
+                           ):
+    raw_background = tar_image.copy()
+    item = process_pairs(ref_image, ref_mask, tar_image, tar_mask, enable_shape_control = enable_shape_control)
+
+    ref = item['ref']
+    hint = item['hint']
+    num_samples = 1
+
+    control = torch.from_numpy(hint.copy()).float().cuda() 
+    control = torch.stack([control for _ in range(num_samples)], dim=0)
+    control = einops.rearrange(control, 'b h w c -> b c h w').clone()
+
+
+    clip_input = torch.from_numpy(ref.copy()).float().cuda() 
+    clip_input = torch.stack([clip_input for _ in range(num_samples)], dim=0)
+    clip_input = einops.rearrange(clip_input, 'b h w c -> b c h w').clone()
+
+    H,W = 512,512
+
+    cond = {"c_concat": [control], "c_crossattn": [model.get_learned_conditioning( clip_input )]}
+    un_cond = {"c_concat": [control], 
+               "c_crossattn": [model.get_learned_conditioning([torch.zeros((1,3,224,224))] * num_samples)]}
+    shape = (4, H // 8, W // 8)
+
+    if save_memory:
+        model.low_vram_shift(is_diffusing=True)
+
+    model.control_scales = ([strength] * 13)
+    samples, _ = ddim_sampler.sample(ddim_steps, num_samples,
+                                     shape, cond, verbose=False, eta=0,
+                                     unconditional_guidance_scale=scale,
+                                     unconditional_conditioning=un_cond)
+
+    if save_memory:
+        model.low_vram_shift(is_diffusing=False)
+
+    x_samples = model.decode_first_stage(samples)
+    x_samples = (einops.rearrange(x_samples, 'b c h w -> b h w c') * 127.5 + 127.5).cpu().numpy()
+
+    result = x_samples[0][:,:,::-1]
+    result = np.clip(result,0,255)
+
+    pred = x_samples[0]
+    pred = np.clip(pred,0,255)[1:,:,:]
+    sizes = item['extra_sizes']
+    tar_box_yyxx_crop = item['tar_box_yyxx_crop'] 
+    tar_image = crop_back(pred, tar_image, sizes, tar_box_yyxx_crop) 
+
+    # keep background unchanged
+    y1,y2,x1,x2 = item['tar_box_yyxx']
+    raw_background[y1:y2, x1:x2, :] = tar_image[y1:y2, x1:x2, :]
+    return raw_background
+
+
+def process_pairs(ref_image, ref_mask, tar_image, tar_mask, max_ratio = 0.8, enable_shape_control = False):
+    # ========= Reference ===========
+    # ref expand 
+    ref_box_yyxx = get_bbox_from_mask(ref_mask)
+
+    # ref filter mask 
+    ref_mask_3 = np.stack([ref_mask,ref_mask,ref_mask],-1)
+    masked_ref_image = ref_image * ref_mask_3 + np.ones_like(ref_image) * 255 * (1-ref_mask_3)
+
+    y1,y2,x1,x2 = ref_box_yyxx
+    masked_ref_image = masked_ref_image[y1:y2,x1:x2,:]
+    ref_mask = ref_mask[y1:y2,x1:x2]
+
+    ratio = np.random.randint(11, 15) / 10 #11,13
+    masked_ref_image, ref_mask = expand_image_mask(masked_ref_image, ref_mask, ratio=ratio)
+    ref_mask_3 = np.stack([ref_mask,ref_mask,ref_mask],-1)
+
+    # to square and resize
+    masked_ref_image = pad_to_square(masked_ref_image, pad_value = 255, random = False)
+    masked_ref_image = cv2.resize(masked_ref_image.astype(np.uint8), (224,224) ).astype(np.uint8)
+
+    ref_mask_3 = pad_to_square(ref_mask_3 * 255, pad_value = 0, random = False)
+    ref_mask_3 = cv2.resize(ref_mask_3.astype(np.uint8), (224,224) ).astype(np.uint8)
+    ref_mask = ref_mask_3[:,:,0]
+
+    # collage aug 
+    masked_ref_image_compose, ref_mask_compose =  masked_ref_image, ref_mask
+    ref_mask_3 = np.stack([ref_mask_compose,ref_mask_compose,ref_mask_compose],-1)
+    ref_image_collage = sobel(masked_ref_image_compose, ref_mask_compose/255)
+
+    # ========= Target ===========
+    tar_box_yyxx = get_bbox_from_mask(tar_mask)
+    tar_box_yyxx = expand_bbox(tar_mask, tar_box_yyxx, ratio=[1.1,1.2]) #1.1  1.3
+    tar_box_yyxx_full = tar_box_yyxx
+    
+    # crop
+    tar_box_yyxx_crop =  expand_bbox(tar_image, tar_box_yyxx, ratio=[1.3, 3.0])   
+    tar_box_yyxx_crop = box2squre(tar_image, tar_box_yyxx_crop) # crop box
+    y1,y2,x1,x2 = tar_box_yyxx_crop
+
+    cropped_target_image = tar_image[y1:y2,x1:x2,:]
+    cropped_tar_mask = tar_mask[y1:y2,x1:x2]
+
+    tar_box_yyxx = box_in_box(tar_box_yyxx, tar_box_yyxx_crop)
+    y1,y2,x1,x2 = tar_box_yyxx
+
+    # collage
+    ref_image_collage = cv2.resize(ref_image_collage.astype(np.uint8), (x2-x1, y2-y1))
+    ref_mask_compose = cv2.resize(ref_mask_compose.astype(np.uint8), (x2-x1, y2-y1))
+    ref_mask_compose = (ref_mask_compose > 128).astype(np.uint8)
+
+    collage = cropped_target_image.copy() 
+    collage[y1:y2,x1:x2,:] = ref_image_collage
+
+    collage_mask = cropped_target_image.copy() * 0.0
+    collage_mask[y1:y2,x1:x2,:] = 1.0
+    if enable_shape_control:
+        collage_mask = np.stack([cropped_tar_mask,cropped_tar_mask,cropped_tar_mask],-1)
+
+    # the size before pad
+    H1, W1 = collage.shape[0], collage.shape[1]
+
+    cropped_target_image = pad_to_square(cropped_target_image, pad_value = 0, random = False).astype(np.uint8)
+    collage = pad_to_square(collage, pad_value = 0, random = False).astype(np.uint8)
+    collage_mask = pad_to_square(collage_mask, pad_value = 2, random = False).astype(np.uint8)
+
+    # the size after pad
+    H2, W2 = collage.shape[0], collage.shape[1]
+
+    cropped_target_image = cv2.resize(cropped_target_image.astype(np.uint8), (512,512)).astype(np.float32)
+    collage = cv2.resize(collage.astype(np.uint8), (512,512)).astype(np.float32)
+    collage_mask  = cv2.resize(collage_mask.astype(np.uint8), (512,512),  interpolation = cv2.INTER_NEAREST).astype(np.float32)
+    collage_mask[collage_mask == 2] = -1
+
+    masked_ref_image = masked_ref_image  / 255 
+    cropped_target_image = cropped_target_image / 127.5 - 1.0
+    collage = collage / 127.5 - 1.0 
+    collage = np.concatenate([collage, collage_mask[:,:,:1]  ] , -1)
+    
+    item = dict(ref=masked_ref_image.copy(), jpg=cropped_target_image.copy(), hint=collage.copy(), 
+                extra_sizes=np.array([H1, W1, H2, W2]), 
+                tar_box_yyxx_crop=np.array( tar_box_yyxx_crop ),
+                tar_box_yyxx=np.array(tar_box_yyxx_full),
+                 ) 
+    return item
+
+
+garment_dir='./examples/Gradio/FG'
+person_dir='./examples/Gradio/BG'
+garment_list=[os.path.join(garment_dir,file) for file in os.listdir(garment_dir) if '.jpg' in file or '.png' in file or '.jpeg' in file ]
+garment_list.sort()
+person_list=[os.path.join(person_dir,file) for file in os.listdir(person_dir) if '.jpg' in file or '.png' in file or '.jpeg' in file]
+person_list.sort()
+
+def mask_image(image, mask):
+    blanc = np.ones_like(image) * 255
+    mask = np.stack([mask,mask,mask],-1) / 255
+    masked_image = mask * ( 0.5 * blanc + 0.5 * image) + (1-mask) * image
+    return masked_image.astype(np.uint8)
+
+def run_local(base,
+              ref,
+              *args):
+    image = base["image"].convert("RGB")
+    mask = base["mask"].convert("L")
+    ref_image = ref["image"].convert("RGB")
+    ref_mask = ref["mask"].convert("L")
+    image = np.asarray(image)
+    mask = np.asarray(mask)
+    mask = np.where(mask > 128, 1, 0).astype(np.uint8)
+    ref_image = np.asarray(ref_image)
+    ref_mask = np.asarray(ref_mask)
+    ref_mask = np.where(ref_mask > 128, 1, 0).astype(np.uint8)
+
+    if ref_mask.sum() == 0:
+        raise gr.Error('No mask for the reference image.')
+
+    if mask.sum() == 0:
+        raise gr.Error('No mask for the background image.')
+
+    if reference_mask_refine:
+        ref_mask = process_image_mask(ref_image, ref_mask)
+
+    synthesis = inference_single_image(ref_image.copy(), ref_mask.copy(), image.copy(), mask.copy(), *args)
+    synthesis = torch.from_numpy(synthesis).permute(2, 0, 1)
+    synthesis = synthesis.permute(1, 2, 0).numpy()
+    return [synthesis]
+
+
+
+with gr.Blocks() as demo:
+    with gr.Column():
+        gr.Markdown("#  Virtual Garment Try-On with AnyDoor")
+        with gr.Row():
+            baseline_gallery = gr.Gallery(label='Output', show_label=True, elem_id="gallery", columns=1, height=768)
+            with gr.Accordion("Advanced Option", open=True):
+                num_samples = 1
+                strength = gr.Slider(label="Control Strength", minimum=0.0, maximum=2.0, value=1.0, step=0.01)
+                ddim_steps = gr.Slider(label="Steps", minimum=1, maximum=100, value=30, step=1)
+                scale = gr.Slider(label="Guidance Scale", minimum=0.1, maximum=30.0, value=4.5, step=0.1)
+                seed = gr.Slider(label="Seed", minimum=-1, maximum=999999999, step=1, value=-1)
+                reference_mask_refine = gr.Checkbox(label='Reference Mask Refine', value=False, interactive = True)
+                enable_shape_control = gr.Checkbox(label='Enable Shape Control', value=False, interactive = True)
+                
+                gr.Markdown("### Guidelines")
+                gr.Markdown(" Higher guidance-scale makes higher fidelity, while lower one makes more harmonized blending.")
+                gr.Markdown(" Users should annotate the mask of the target object, too coarse mask would lead to bad generation.\
+                              Reference Mask Refine provides a segmentation model to refine the coarse mask. ")
+                gr.Markdown(" Enable shape control means the generation results would consider user-drawn masks to control the shape & pose; otherwise it \
+                              considers the location and size to adjust automatically.")
+
+    
+        gr.Markdown("# Upload a Person Image (left) and a Garment Image (right)")
+        gr.Markdown("### Draw a mask on the person to specify where the clothes should appear.")
+        gr.Markdown("### <u>Do not forget</u> to annotate the garment region on the clothing image.")
+        with gr.Row():
+            base = gr.Image(label="Person", source="upload", tool="sketch", type="pil", height=512, brush_color='#FFFFFF', mask_opacity=0.5)
+            ref = gr.Image(label="Garment", source="upload", tool="sketch", type="pil", height=512, brush_color='#FFFFFF', mask_opacity=0.5)
+        run_local_button = gr.Button(label="Generate", value="Run")
+
+        with gr.Row():
+            with gr.Column():
+                gr.Examples(person_list, inputs=[base],label="Examples - Person Image",examples_per_page=16)
+            with gr.Column():
+                gr.Examples(garment_list, inputs=[ref],label="Examples - Garment",examples_per_page=16)
+        
+    run_local_button.click(fn=run_local, 
+                           inputs=[base, 
+                                   ref, 
+                                   strength, 
+                                   ddim_steps, 
+                                   scale, 
+                                   seed,
+                                   enable_shape_control, 
+                                   ], 
+                           outputs=[baseline_gallery]
+                        )
+
+demo.launch(server_name="0.0.0.0")


### PR DESCRIPTION
## Summary
- add `run_tryon_demo.py` for virtual garment try-on
- add configuration `configs/tryon_demo.yaml`
- document usage in `TRYON_TUTORIAL.md` and update README

## Testing
- `python -m py_compile run_tryon_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68590c104988832398591fd7feb4d28b